### PR TITLE
Ensure no optional parameters are before required parameters

### DIFF
--- a/Model/Types/AbandonedCarts.php
+++ b/Model/Types/AbandonedCarts.php
@@ -28,7 +28,7 @@ class AbandonedCarts
         $this->abandonedCartFactory = $abandonedCartFactory;
     }
 
-    public function load($pageSize, $pageNum, $startDate = null, $endDate = null, $sortDir, $filterBy, $id)
+    public function load($pageSize, $pageNum, $startDate, $endDate, $sortDir, $filterBy, $id)
     {
         $config = $this->helper->getConfig();
         $this->pageNum = $pageNum;

--- a/Model/Types/Categories.php
+++ b/Model/Types/Categories.php
@@ -28,7 +28,7 @@ class Categories {
         $this->categoryFactory = $categoryFactory;
     }
 
-    public function load($pageSize, $pageNum, $startDate = null, $endDate = null, $sortDir, $filterBy, $id)
+    public function load($pageSize, $pageNum, $startDate, $endDate, $sortDir, $filterBy, $id)
     {
         $config = $this->helper->getConfig();
         $this->pageNum = $pageNum;

--- a/Model/Types/Customers.php
+++ b/Model/Types/Customers.php
@@ -20,7 +20,7 @@ class Customers {
         $this->customerFactory = $customerFactory;
         $this->objectManager = $objectManager;
     }
-    public function load($pageSize, $pageNum, $startDate = null, $endDate = null, $sortDir, $filterBy, $id) {
+    public function load($pageSize, $pageNum, $startDate, $endDate, $sortDir, $filterBy, $id) {
         $config = $this->helper->getConfig();
         $this->pageNum = $pageNum;
         if ($id) {

--- a/Model/Types/OrderItems.php
+++ b/Model/Types/OrderItems.php
@@ -31,7 +31,7 @@ class OrderItems {
         $this->resource = $resource;
         $this->productMetadata = $productMetadata;
     }
-    public function load($pageSize, $pageNum, $startDate = null, $endDate = null, $sortDir, $filterBy, $id, $customAttr, $ignoreCost)
+    public function load($pageSize, $pageNum, $startDate, $endDate, $sortDir, $filterBy, $id, $customAttr, $ignoreCost)
     {
         $config = $this->helper->getConfig();
         $store = $this->helper->getStore();

--- a/Model/Types/Orders.php
+++ b/Model/Types/Orders.php
@@ -20,7 +20,7 @@ class Orders {
         $this->orderCollection = $orderCollection;
         $this->objectManager = $objectManager;
     }
-    public function load($pageSize, $pageNum, $startDate = null, $endDate = null, $sortDir, $filterBy, $id)
+    public function load($pageSize, $pageNum, $startDate, $endDate, $sortDir, $filterBy, $id)
     {
         $config = $this->helper->getConfig();
         $this->pageNum = $pageNum;

--- a/Model/Types/ProductAlerts.php
+++ b/Model/Types/ProductAlerts.php
@@ -28,7 +28,7 @@ class ProductAlerts {
         $this->productAlertFactory = $productAlertFactory;
     }
 
-    public function load($pageSize, $pageNum, $startDate = null, $endDate = null, $sortDir, $filterBy, $id)
+    public function load($pageSize, $pageNum, $startDate, $endDate, $sortDir, $filterBy, $id)
     {
         $config = $this->helper->getConfig();
         $this->pageNum = $pageNum;

--- a/Model/Types/Products.php
+++ b/Model/Types/Products.php
@@ -28,7 +28,7 @@ class Products {
         $this->resource = $resource;
         $this->productMetadata = $productMetadata;
     }
-    public function load($pageSize, $pageNum, $startDate = null, $endDate = null, $sortDir, $filterBy, $id)
+    public function load($pageSize, $pageNum, $startDate, $endDate, $sortDir, $filterBy, $id)
     {
         $config = $this->helper->getConfig();
         $edition = $this->productMetadata->getEdition();

--- a/Model/Types/RefundItems.php
+++ b/Model/Types/RefundItems.php
@@ -33,7 +33,7 @@ class RefundItems {
         $this->resource = $resource;
     }
 
-    public function load($pageSize, $pageNum, $startDate = null, $endDate = null, $sortDir, $filterBy, $id)
+    public function load($pageSize, $pageNum, $startDate, $endDate, $sortDir, $filterBy, $id)
     {
         $config = $this->helper->getConfig();
         $this->pageNum = $pageNum;

--- a/Model/Types/Refunds.php
+++ b/Model/Types/Refunds.php
@@ -28,7 +28,7 @@ class Refunds {
         $this->refundFactory = $refundFactory;
     }
 
-    public function load($pageSize, $pageNum, $startDate = null, $endDate = null, $sortDir, $filterBy, $id)
+    public function load($pageSize, $pageNum, $startDate, $endDate, $sortDir, $filterBy, $id)
     {
         $config = $this->helper->getConfig();
         $this->pageNum = $pageNum;


### PR DESCRIPTION
`$startDate` and `$endDate` are always passed through where these functions are called, so no reason for them to be optional.